### PR TITLE
fix restart of result sharing when new block lambda is used

### DIFF
--- a/core/src/main/kotlin/com/kiwi/navigationcompose/typed/ResultSharing.kt
+++ b/core/src/main/kotlin/com/kiwi/navigationcompose/typed/ResultSharing.kt
@@ -82,7 +82,7 @@ public fun <R : Any> ResultEffectImpl(
 	resultSerializer: KSerializer<R>,
 	block: (R) -> Unit,
 ) {
-	DisposableEffect(navController, block) {
+	DisposableEffect(navController) {
 		// The implementation is based on the official documentation of the Result sharing.
 		// It takes into consideration the possibility of a dialog usage (see the docs).
 		// https://developer.android.com/guide/navigation/navigation-programmatic#additional_considerations


### PR DESCRIPTION
closes #33

this can happen quite often as the lambdas may not be correctly auto-remembered